### PR TITLE
fix: Form.Group example fix

### DIFF
--- a/src/Form/form-group.mdx
+++ b/src/Form/form-group.mdx
@@ -38,7 +38,7 @@ context. `Form.Control`, `Form.Label`, and `Form.Control.Feedback` consume this 
   >
     <Form.Label>What kind of cats?</Form.Label>
     <Form.Control />
-    <Form.Control.Feedback type="valid">You are incorrect!</Form.Control.Feedback>
+    <Form.Control.Feedback type="valid">You are correct!</Form.Control.Feedback>
   </Form.Group>
 ```
 


### PR DESCRIPTION
## Description

The below example is using isValid, yet the feedback text says “incorrect” (it should say “correct”)

### Deploy Preview

Include a direct link to your changes in this PR's deploy preview here (e.g., a specific component page).

## Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Netlify deploy preview, if applicable.
* [ ] Does your change adhere to the documented [style conventions](https://github.com/openedx/paragon/blob/master/docs/decisions/0012-css-styling-conventions)?
* [ ] Do any prop types have missing descriptions in the Props API tables in the documentation site (check deploy preview)?
* [ ] Were your changes tested using all available themes (see theme switcher in the header of the deploy preview, under the "Settings" icon)?
* [ ] Were your changes tested in the `example` app?
* [ ] Is there adequate test coverage for your changes?
* [ ] Consider whether this change needs to reviewed/QA'ed for accessibility (a11y). If so, please add `wittjeff` and `adamstankiewicz` as reviewers on this PR.

## Post-merge Checklist

* [ ] Verify your changes were released to [NPM](https://www.npmjs.com/package/@edx/paragon) at the expected version.
* [ ] If you'd like, [share](https://github.com/openedx/paragon/discussions/new?category=show-and-tell) your contribution in [#show-and-tell](https://github.com/openedx/paragon/discussions/categories/show-and-tell).
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
